### PR TITLE
Fix Ironic HA portgroup post wrong naming in title

### DIFF
--- a/_posts/2017-05-31-high-availability-of-bare-metal.md
+++ b/_posts/2017-05-31-high-availability-of-bare-metal.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: High availability of Bare Metal: Link Aggressive support in Linux with Fujitsu Server
-date: 2017-05-30
+title: High availability of Bare Metal - Link Aggressive support in Linux with Fujitsu Server
+date: 2017-05-31
 type: post
 published: true
 status: publish

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "autoprefixer-stylus": "^0.4.0",
     "browser-sync": "^1.9.0",
     "grunt": "^0.4.5",
-    "gulp": "^3.8.10",
+    "gulp": "^3.9.1",
     "gulp-concat": "^2.4.3",
     "gulp-imagemin": "^2.1.0",
     "gulp-plumber": "^0.6.6",


### PR DESCRIPTION
Title is not allowed to contain ':' char, cause jekyll misunderstood
while compiling.
Also change the date of this post to latest.